### PR TITLE
Add None default for image fetch

### DIFF
--- a/API/auth/routers.py
+++ b/API/auth/routers.py
@@ -59,7 +59,7 @@ def callback(request: Request):
     user_data = {
         "id": data.get("id"),
         "username": data.get("display_name"),
-        "img_url": data.get("img").get("href"),
+        "img_url": data.get("img").get("href", default = None),
     }
 
     token = serializer.dumps(user_data)


### PR DESCRIPTION
Fixes #81 by allowing a `None` default if a user does not have an image for their OSM profile. 