### PR TITLE
Return none for null image key/value

### DIFF
--- a/API/auth/routers.py
+++ b/API/auth/routers.py
@@ -59,7 +59,7 @@ def callback(request: Request):
     user_data = {
         "id": data.get("id"),
         "username": data.get("display_name"),
-        "img_url": data.get("img").get("href", default = None),
+        "img_url": data.get("img").get("href") if data.get("img") else None,
     }
 
     token = serializer.dumps(user_data)


### PR DESCRIPTION
This is an improvement on the previous fix to ensure `None` is returned for a user that does not have an image at all, i.e if the `img` key is non-existent, return None. 

