### PR TITLE
Show recency of data per data source

### DIFF
--- a/API/main.py
+++ b/API/main.py
@@ -35,6 +35,8 @@ from .tasking_manager import router as tm_router
 from .raw_data import router as raw_data_router
 from .download_export import router as download_router
 from .test_router import router as test_router
+from .status import router as status_router
+from fastapi import  Request
 from fastapi.responses import JSONResponse
 from src.galaxy.db_session import database_instance
 from src.galaxy.config import use_connection_pooling , use_s3_to_upload ,logger as logging,config
@@ -66,6 +68,7 @@ app.include_router(data_quality_router)
 # app.include_router(training_router)
 app.include_router(hashtag_router)
 app.include_router(tm_router)
+app.include_router(status_router)
 app.include_router(raw_data_router)
 if use_s3_to_upload is False : # only mount the disk if config is set to disk 
     app.include_router(download_router)
@@ -128,5 +131,3 @@ def on_shutdown():
     if use_connection_pooling:
         logging.debug("Shutting down connection pool")
         database_instance.close_all_connection_pool()
-
-

--- a/API/raw_data.py
+++ b/API/raw_data.py
@@ -324,6 +324,3 @@ def watch_s3_upload(url : str,path : str) -> None:
         logging.debug("File is uploaded at %s , flushing out from %s",url,path)  
         os.unlink(path)
 
-
-
-

--- a/API/status.py
+++ b/API/status.py
@@ -22,31 +22,29 @@
 """
 
 from fastapi import APIRouter
-from src.galaxy.validation.models import DataSource
+from src.galaxy.validation.models import DataOutput, DataSource, DataRecencyParams
 from src.galaxy.app import Status
 
 router = APIRouter(prefix="/status")
 
-@router.get("/{data_source}")
-def get_current_database_status(data_source: DataSource):
-    """Gives the database update status depending on the source"""
-    status = Status(data_source)
-    result = None
+@router.post("/")
+def data_recency_status(params: DataRecencyParams):
+  """Gives the time lapse since the last update per data source per data output"""
+  result = None
+  db = Status(params)
 
-    if data_source == DataSource.INSIGHTS.value:
-      result = status.check_insights_status()
+  if (params.data_source == DataSource.INSIGHTS.value):
+    if (params.data_output == DataOutput.OSM.value):
+      result = db.get_osm_recency()
+    elif(params.data_output == DataOutput.mapathon_statistics.value):
+      result = db.get_mapathon_statistics_recency()
+    elif(params.data_output == DataOutput.user_statistics.value):
+      result = db.get_user_statistics_recency()
 
-    if data_source == DataSource.UNDERPASS.value:
-      result = status.check_underpass_status()
+  if (params.data_source == DataSource.UNDERPASS.value):
+    if (params.data_output == DataOutput.OSM.value):
+      result = db.get_osm_recency()
+    elif(params.data_output == DataOutput.data_quality.value):
+      result = db.get_user_data_quality_recency()
 
-    # result = result/60 #convert to minutes
-
-    # if int(result) == 0:
-    #   response = "less than a minute ago"
-    # elif int(result) == 1:
-    #    response = "1 minute ago"
-    # else:
-    #   response = f"""{int(result)} minutes ago"""
-
-    # return { "last_updated": response }
-    return { "last_updated_seconds": result }
+  return { "time_difference": str(result) if result else None }

--- a/API/status.py
+++ b/API/status.py
@@ -61,7 +61,7 @@ def data_recency_status(params: DataRecencyParams):
     """
     result = None
     db = Status(params)
-    if (params.data_output == DataOutput.OSM.value):
+    if (params.data_output == DataOutput.osm.value):
       result = db.get_osm_recency()
     elif(params.data_output == DataOutput.mapathon_statistics.value):
       result = db.get_mapathon_statistics_recency()

--- a/API/status.py
+++ b/API/status.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2021 Humanitarian OpenStreetmap Team
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# Humanitarian OpenStreetmap Team
+# 1100 13th Street NW Suite 800 Washington, D.C. 20005
+# <info@hotosm.org>
+
+"""
+  Router Responsible for Data Source Update Status
+"""
+
+from fastapi import APIRouter
+from src.galaxy.validation.models import DataSource
+from src.galaxy.app import Status
+
+router = APIRouter(prefix="/status")
+
+@router.get("/{data_source}")
+def get_current_database_status(data_source: DataSource):
+    """Gives the database update status depending on the source"""
+    status = Status(data_source)
+    result = None
+
+    if data_source == DataSource.INSIGHTS.value:
+      result = status.check_insights_status()
+
+    if data_source == DataSource.UNDERPASS.value:
+      result = status.check_underpass_status()
+
+    # result = result/60 #convert to minutes
+
+    # if int(result) == 0:
+    #   response = "less than a minute ago"
+    # elif int(result) == 1:
+    #    response = "1 minute ago"
+    # else:
+    #   response = f"""{int(result)} minutes ago"""
+
+    # return { "last_updated": response }
+    return { "last_updated_seconds": result }

--- a/API/status.py
+++ b/API/status.py
@@ -22,13 +22,43 @@
 """
 
 from fastapi import APIRouter
+from fastapi_versioning import version
 from src.galaxy.validation.models import DataOutput, DataSource, DataRecencyParams
 from src.galaxy.app import Status
 router = APIRouter(prefix="/status")
 
 @router.post("/")
+@version(1)
 def data_recency_status(params: DataRecencyParams):
-    """Gives the time lapse since the last update per data source per data output"""
+    """Gives the time lapse since the last update per data source per data output
+
+    Args:
+        params (DataRecencyParams):
+
+        {
+          "dataSource": "string" #the database from which the stats/data are got,
+          "dataOutput": "string" #the kind of stats/data
+        }
+
+    Returns:
+      
+        {
+          "time_difference": "1 day, 00:03:20" #time
+        }
+                        
+    Example Request:
+
+        {
+          "dataSource": "underpass",
+          "dataOutput": "mapathon_statistics"
+        }
+
+    Example Response :
+    
+        {
+          "time_difference": "00:00:10"     
+        }    
+    """
     result = None
     db = Status(params)
     if (params.data_output == DataOutput.OSM.value):

--- a/API/status.py
+++ b/API/status.py
@@ -32,14 +32,14 @@ def data_recency_status(params: DataRecencyParams):
     result = None
     db = Status(params)
     if (params.data_output == DataOutput.OSM.value):
-        result = db.get_osm_recency()
+      result = db.get_osm_recency()
     elif(params.data_output == DataOutput.mapathon_statistics.value):
-        result = db.get_mapathon_statistics_recency()
+      result = db.get_mapathon_statistics_recency()
     elif(params.data_output == DataOutput.user_statistics.value):
-        result = db.get_user_statistics_recency()
+      result = db.get_user_statistics_recency()
     elif(params.data_output == DataOutput.data_quality.value):
-        result = db.get_user_data_quality_recency()
+      result = db.get_user_data_quality_recency()
     elif params.data_output == DataOutput.raw_data.value:
-        result = db.get_raw_data_recency() if params.data_source is DataSource.UNDERPASS.value else None
+      result = db.get_raw_data_recency() if params.data_source is DataSource.UNDERPASS.value else None
 
     return { "time_difference": str(result) if result else None }

--- a/API/status.py
+++ b/API/status.py
@@ -24,27 +24,22 @@
 from fastapi import APIRouter
 from src.galaxy.validation.models import DataOutput, DataSource, DataRecencyParams
 from src.galaxy.app import Status
-
 router = APIRouter(prefix="/status")
 
 @router.post("/")
 def data_recency_status(params: DataRecencyParams):
-  """Gives the time lapse since the last update per data source per data output"""
-  result = None
-  db = Status(params)
-
-  if (params.data_source == DataSource.INSIGHTS.value):
+    """Gives the time lapse since the last update per data source per data output"""
+    result = None
+    db = Status(params)
     if (params.data_output == DataOutput.OSM.value):
-      result = db.get_osm_recency()
+        result = db.get_osm_recency()
     elif(params.data_output == DataOutput.mapathon_statistics.value):
-      result = db.get_mapathon_statistics_recency()
+        result = db.get_mapathon_statistics_recency()
     elif(params.data_output == DataOutput.user_statistics.value):
-      result = db.get_user_statistics_recency()
-
-  if (params.data_source == DataSource.UNDERPASS.value):
-    if (params.data_output == DataOutput.OSM.value):
-      result = db.get_osm_recency()
+        result = db.get_user_statistics_recency()
     elif(params.data_output == DataOutput.data_quality.value):
-      result = db.get_user_data_quality_recency()
+        result = db.get_user_data_quality_recency()
+    elif params.data_output == DataOutput.raw_data.value:
+        result = db.get_raw_data_recency() if params.data_source is DataSource.UNDERPASS.value else None
 
-  return { "time_difference": str(result) if result else None }
+    return { "time_difference": str(result) if result else None }

--- a/src/galaxy/app.py
+++ b/src/galaxy/app.py
@@ -222,13 +222,13 @@ class Underpass:
         """OSM synchronisation"""
         status_query = check_last_updated_osm_underpass()
         result = self.database.executequery(status_query)
-        return result
+        return result[0][0]
 
     def get_user_data_quality_last_updated(self):
         """ Recency of user data quality reports"""
         status_query = check_last_updated_user_data_quality_underpass()
         result = self.database.executequery(status_query)
-        return result
+        return result[0][0]
 
 
 class Insight:
@@ -282,13 +282,13 @@ class Insight:
         """Recency of mapathon statistics"""
         status_query = check_last_updated_mapathon_insights()
         result = self.database.executequery(status_query)
-        return result
+        return result[0][0]
 
     def get_user_statistics_last_updated(self):
         """Recency of user statistics"""
         status_query = check_last_updated_user_statistics_insights()
         result = self.database.executequery(status_query)
-        return result
+        return result[0][0]
 
 
 class TaskingManager:
@@ -795,21 +795,20 @@ class Status:
         else:
             raise ValueError("Source is not Supported")
 
-    def get_osm_recency(self):
-        result = self.database.get_osm_last_updated()
-        return result[0][0]
-        
+     def get_osm_recency(self):
+        return self.database.get_osm_last_updated() if getattr(self.database, "get_osm_last_updated", None) else None 
+
     def get_mapathon_statistics_recency(self):
-        result = self.database.get_mapathon_statistics_last_updated()
-        return result[0][0]
+        return self.database.get_mapathon_statistics_last_updated() if getattr(self.database, "get_mapathon_statistics_last_updated", None) else None 
 
     def get_user_statistics_recency(self):
-        result =  self.database.get_user_statistics_last_updated()
-        return result[0][0]   
+        return self.database.get_user_statistics_last_updated() if getattr(self.database, "get_user_statistics_last_updated", None) else None 
 
     def get_user_data_quality_recency(self):
-        result =  self.database.get_user_data_quality_last_updated()
-        return result[0][0]
+        return self.database.get_user_data_quality_last_updated() if getattr(self.database, "get_user_data_quality_last_updated", None) else None
+
+    def get_raw_data_recency(self):
+        return RawData.check_status()
 
 
 class RawData:
@@ -1249,3 +1248,4 @@ class ProgressPercentage(object):
             self._seen_so_far += bytes_amount
             percentage = (self._seen_so_far / self._size) * 100
             logging.debug("\r%s  %s / %s  (%.2f%%)" ,self._filename, self._seen_so_far, self._size,percentage)
+

--- a/src/galaxy/app.py
+++ b/src/galaxy/app.py
@@ -809,7 +809,7 @@ class Status:
         return self.database.get_user_data_quality_last_updated() if getattr(self.database, "get_user_data_quality_last_updated", None) else None
 
     def get_raw_data_recency(self):
-        return RawData.check_status()
+        return RawData().check_status()
 
 
 class RawData:

--- a/src/galaxy/app.py
+++ b/src/galaxy/app.py
@@ -795,8 +795,9 @@ class Status:
         else:
             raise ValueError("Source is not Supported")
 
+
     def get_osm_recency(self):
-        return self.database.get_osm_last_updated() if getattr(self.database, "get_osm_last_updated", None) else None # checks either that method is supported by the database supplied or not without making call to database if yes will make a call else it will return None without calling class
+        return self.database.get_osm_last_updated() if getattr(self.database, "get_osm_last_updated", None) else None # checks either that method is supported by the database supplied or not without making call to database class if yes will make a call else it will return None 
 
     def get_mapathon_statistics_recency(self):
         return self.database.get_mapathon_statistics_last_updated() if getattr(self.database, "get_mapathon_statistics_last_updated", None) else None 

--- a/src/galaxy/app.py
+++ b/src/galaxy/app.py
@@ -747,6 +747,31 @@ class OrganizationHashtags:
             return err  
 
 
+class Status:
+    """Class to show how recent the data is from different data sources"""
+
+    # constructor
+    def __init__(self, source):
+        if source == DataSource.UNDERPASS.value:
+            self.database = Database(get_db_connection_params("UNDERPASS"))
+        elif source == DataSource.INSIGHTS.value:
+            self.database = Database(get_db_connection_params("INSIGHTS"))
+        else:
+            raise ValueError("Source is not Supported")
+        
+        self.con, self.cur = self.database.connect()
+
+    def check_insights_status(self):
+        status_query = check_last_updated_insights()
+        result = self.database.executequery(status_query)
+        return result[0][0].total_seconds()
+
+    def check_underpass_status(self):
+        status_query = check_last_updated_underpass()
+        result = self.database.executequery(status_query)
+        return result[0][0].total_seconds()
+
+
 class RawData:
     """Class responsible for the Rawdata Extraction from available sources ,
         Currently Works for Underpass source Current Snapshot
@@ -1184,3 +1209,4 @@ class ProgressPercentage(object):
             self._seen_so_far += bytes_amount
             percentage = (self._seen_so_far / self._size) * 100
             logging.debug("\r%s  %s / %s  (%.2f%%)" ,self._filename, self._seen_so_far, self._size,percentage)
+

--- a/src/galaxy/app.py
+++ b/src/galaxy/app.py
@@ -795,8 +795,8 @@ class Status:
         else:
             raise ValueError("Source is not Supported")
 
-     def get_osm_recency(self):
-        return self.database.get_osm_last_updated() if getattr(self.database, "get_osm_last_updated", None) else None 
+    def get_osm_recency(self):
+        return self.database.get_osm_last_updated() if getattr(self.database, "get_osm_last_updated", None) else None # checks either that method is supported by the database supplied or not without making call to database if yes will make a call else it will return None without calling class
 
     def get_mapathon_statistics_recency(self):
         return self.database.get_mapathon_statistics_last_updated() if getattr(self.database, "get_mapathon_statistics_last_updated", None) else None 
@@ -1188,7 +1188,6 @@ class S3FileTransfer :
         except Exception as ex:
             logging.error(ex)
             raise ex
-
         
     def list_buckets(self):
         """used to list all the buckets available on s3"""

--- a/src/galaxy/app.py
+++ b/src/galaxy/app.py
@@ -276,7 +276,7 @@ class Insight:
         """OSM synchronisation"""
         status_query = check_last_updated_osm_insights()
         result = self.database.executequery(status_query)
-        return result
+        return result[0][0]
 
     def get_mapathon_statistics_last_updated(self):
         """Recency of mapathon statistics"""
@@ -808,7 +808,7 @@ class Status:
     def get_user_data_quality_recency(self):
         return self.database.get_user_data_quality_last_updated() if getattr(self.database, "get_user_data_quality_last_updated", None) else None
 
-    def get_raw_data_recency(self):
+    def get_raw_data_recency(self): 
         return RawData().check_status()
 
 
@@ -1249,3 +1249,4 @@ class ProgressPercentage(object):
             percentage = (self._seen_so_far / self._size) * 100
             logging.debug("\r%s  %s / %s  (%.2f%%)" ,self._filename, self._seen_so_far, self._size,percentage)
 
+        

--- a/src/galaxy/query_builder/builder.py
+++ b/src/galaxy/query_builder/builder.py
@@ -1135,3 +1135,10 @@ def check_last_updated_rawdata():
     query = f"""select NOW()-importdate as last_updated from planet_osm_replication_status"""
     return query
     
+def check_last_updated_insights():
+    query = f"""SELECT (NOW() - last_timestamp) AS "last_updated" FROM public.osm_element_history_state;"""
+    return query
+
+def check_last_updated_underpass():
+    query = f"""SELECT (NOW() - MAX(updated_at)) AS "last_updated" FROM public.changesets;"""
+    return query

--- a/src/galaxy/query_builder/builder.py
+++ b/src/galaxy/query_builder/builder.py
@@ -1135,10 +1135,22 @@ def check_last_updated_rawdata():
     query = f"""select NOW()-importdate as last_updated from planet_osm_replication_status"""
     return query
     
-def check_last_updated_insights():
+def check_last_updated_mapathon_insights():
     query = f"""SELECT (NOW() - last_timestamp) AS "last_updated" FROM public.osm_element_history_state;"""
     return query
 
-def check_last_updated_underpass():
+def check_last_updated_osm_insights():
+    query = f"""SELECT (NOW() - last_timestamp) AS "last_updated" FROM public.osm_element_history_state;"""
+    return query
+
+def check_last_updated_user_statistics_insights():
+    query = f"""SELECT (now() - max(timestamp)) FROM public.osm_element_history where changeset = (SELECT max(changeset) FROM public.all_changesets_stats);"""
+    return query
+
+def check_last_updated_osm_underpass():
     query = f"""SELECT (NOW() - MAX(updated_at)) AS "last_updated" FROM public.changesets;"""
+    return query
+
+def check_last_updated_user_data_quality_underpass():
+    query = f"""SELECT (now() - max(updated_at)) FROM public.changesets;"""
     return query

--- a/src/galaxy/validation/models.py
+++ b/src/galaxy/validation/models.py
@@ -606,7 +606,7 @@ class DataSource(str, Enum):
     INSIGHTS = "insight"
 
 class DataOutput(str, Enum):
-    OSM = "osm"
+    osm = "osm"
     mapathon_statistics = "mapathon_statistics"
     data_quality = "data_quality"
     user_statistics = "user_statistics"

--- a/src/galaxy/validation/models.py
+++ b/src/galaxy/validation/models.py
@@ -600,3 +600,7 @@ class UserStatistics(BaseModel):
     modified_highway : int  
     added_highway_meters : float
     modified_highway_meters : float
+
+class DataSource(str, Enum):
+    UNDERPASS = "underpass"
+    INSIGHTS = "insights"

--- a/src/galaxy/validation/models.py
+++ b/src/galaxy/validation/models.py
@@ -603,4 +603,15 @@ class UserStatistics(BaseModel):
 
 class DataSource(str, Enum):
     UNDERPASS = "underpass"
-    INSIGHTS = "insights"
+    INSIGHTS = "insight"
+
+class DataOutput(str, Enum):
+    OSM = "osm"
+    mapathon_statistics = "mapathon statistics"
+    data_quality = "data quality"
+    user_statistics = "user statistics"
+    raw_data = "raw data"
+
+class DataRecencyParams(BaseModel):
+    data_source: DataSource
+    data_output: DataOutput

--- a/src/galaxy/validation/models.py
+++ b/src/galaxy/validation/models.py
@@ -607,10 +607,10 @@ class DataSource(str, Enum):
 
 class DataOutput(str, Enum):
     OSM = "osm"
-    mapathon_statistics = "mapathon statistics"
-    data_quality = "data quality"
-    user_statistics = "user statistics"
-    raw_data = "raw data"
+    mapathon_statistics = "mapathon_statistics"
+    data_quality = "data_quality"
+    user_statistics = "user_statistics"
+    raw_data = "raw_data"
 
 class DataRecencyParams(BaseModel):
     data_source: DataSource


### PR DESCRIPTION
What does this PR do? 
- Fixes #253 

How to test:

Via the `/status` endpoint, you can run 
```
{
  "dataSource": "underpass",
  "dataOutput": "data_quality"
}
```
in order to get back a JSON response with the duration since the last update of the data/stats per the data source. 
