### PR TITLE
Multipolygon support for geometry type : Rawdata endpoint 

### DIFF
--- a/src/galaxy/validation/models.py
+++ b/src/galaxy/validation/models.py
@@ -536,7 +536,7 @@ class SupportedGeometryFilters(Enum):
 class RawDataCurrentParams(BaseModel):
     output_type : Optional[RawDataOutputType]=None
     file_name : Optional[str]=None
-    geometry : Polygon
+    geometry : Union[Polygon,MultiPolygon]
     filters : Optional[dict]=None
     geometry_type : Optional[List[SupportedGeometryFilters]] = None
     


### PR DESCRIPTION
- Resolve https://github.com/hotosm/osm-export-tool/issues/414
- Resolve #293

This PR enables user to pass both multipolygon format geometry and polygon geometry too , most of the geometry type in multipolygon format in export tool geometry section . This doesn't mean API can support n number of polygons , API will support only one geometry but in format of polygon geom and multipolygon geom 
for eg : API now supports following type of geometry too : 
"geometry": { "type": "MultiPolygon", "coordinates": [ [ 