### PR TITLE
Mapathon: Underpass as default data source for mapathons

### DIFF
--- a/API/mapathon.py
+++ b/API/mapathon.py
@@ -34,16 +34,19 @@ router = APIRouter(prefix="/mapathon")
 @router.post("/detail", response_model=MapathonDetail)
 def get_mapathon_detailed_report(params: MapathonRequestParams,
                                  user_data=Depends(login_required)):
-    mapathon = Mapathon(params,"insight")
+    if params.source == "insight":
+        mapathon = Mapathon(params,"insight")
+    else:
+        mapathon = Mapathon(params,"underpass")
     return mapathon.get_detailed_report()
 
 
 @router.post("/summary", response_model=MapathonSummary)
 def get_mapathon_summary(params: MapathonRequestParams):
    
-    if params.source == "underpass":
-        mapathon = Mapathon(params,"underpass")
-    else:
+    if params.source == "insight":
         mapathon = Mapathon(params,"insight")
+    else:
+        mapathon = Mapathon(params,"underpass")
     
     return mapathon.get_summary()

--- a/src/galaxy/app.py
+++ b/src/galaxy/app.py
@@ -198,6 +198,15 @@ class Underpass:
         
         return user_role
 
+    def get_mapathon_detailed_result(self):
+        changeset_query, _, _ = create_changeset_query_underpass(
+            self.params, self.con, self.cur)
+        contributors_query = create_users_contributions_query_underpass(
+            self.params, self.con, self.cur)
+        changesets = self.database.executequery(changeset_query)
+        contributors = self.database.executequery(contributors_query)
+        return changesets, contributors
+
 
 class Insight:
     """This class connects to Insight database and responsible for all the Insight related functionality"""

--- a/src/galaxy/app.py
+++ b/src/galaxy/app.py
@@ -479,9 +479,8 @@ class Mapathon:
                                 time_spent_validating=time_validating_stats)]
 
         report = MapathonDetail(contributors=contributors,
-                                mapped_features=mapped_features)
-                                # ,
-                                # tm_stats=tm_stats)
+                                mapped_features=mapped_features,
+                                tm_stats=tm_stats)
         # print(Output(osm_history_query,self.con).to_list())
         return report
 

--- a/src/galaxy/app.py
+++ b/src/galaxy/app.py
@@ -227,6 +227,7 @@ class Underpass:
         return result[0][0]
         
     def get_mapathon_detailed_result(self):
+        """Functions that returns detailed reports  for mapathon results_dicts"""
         changeset_query, _, _ = create_changeset_query_underpass(
             self.params, self.con, self.cur)
         contributors_query = create_users_contributions_query_underpass(
@@ -567,7 +568,7 @@ class Output:
 
         features = self.dataframe.apply(
             lambda row: Feature(geometry=Point(
-                (float(row[lng_column]), float(row[lat_column]))),
+                ( float(row[lng_column]), float(row[lat_column]) )),
                 properties=properties[row.name]),
             axis=1).tolist()
 
@@ -678,7 +679,7 @@ class DataQualityHashtags:
                 "type": "Feature",
                 "geometry": {
                     "type": "Point",
-                    "coordinates": [row["lon"], row["lat"]]
+                    "coordinates": [row["lat"], row["lon"]]
                 },
                 "properties": {
                     "created_at": row["created_at"],

--- a/src/galaxy/query_builder/builder.py
+++ b/src/galaxy/query_builder/builder.py
@@ -353,7 +353,7 @@ def generate_data_quality_hashtag_reports(cur, params):
     return query
 
 
-def create_hashtagfilter_underpass(hashtags, project_ids, columnname = 'hashtags'):
+def create_hashtagfilter_underpass(hashtags, columnname, project_ids = []):
     """Generates hashtag filter query on the basis of list of hastags."""
     
     hashtag_filter_values = [
@@ -555,7 +555,7 @@ def generate_mapathon_summary_underpass_query(params, cur):
 def create_changeset_query_underpass(params, conn, cur):
     '''returns the changeset query from Underpass'''
 
-    hashtag_filter=create_hashtagfilter_underpass(params.hashtags, params.project_ids, "hashtags")
+    hashtag_filter=create_hashtagfilter_underpass(params.hashtags, "hashtags", params.project_ids)
     timestamp_filter=create_timestamp_filter_query("created_at",params.from_timestamp, params.to_timestamp,cur)
 
     changeset_query = f"""
@@ -582,7 +582,7 @@ def create_changeset_query_underpass(params, conn, cur):
 def create_users_contributions_query_underpass(params, conn, cur):
     '''returns the changeset query from Underpass'''
 
-    hashtag_filter=create_hashtagfilter_underpass(params.hashtags, params.project_ids, "hashtags")
+    hashtag_filter=create_hashtagfilter_underpass(params.hashtags, "hashtags", params.project_ids)
     timestamp_filter=create_timestamp_filter_query("created_at",params.from_timestamp, params.to_timestamp,cur)
 
     contributors_query = f"""


### PR DESCRIPTION
As we have tags stats on the Underpass database, I replaced Insights with Underpass as default data source for mapathons:

- Added detailed report
- Fixed hashtag filter 
- Setup Underpass as the default data source for mapathons
- Fixed lat/lon on GeoJSON response

