### PR TITLE
Expand timestamp limit to 1 week

### DIFF
--- a/API/main.py
+++ b/API/main.py
@@ -18,6 +18,7 @@
 # <info@hotosm.org>
 import time
 
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 import sentry_sdk

--- a/src/galaxy/validation/models.py
+++ b/src/galaxy/validation/models.py
@@ -135,9 +135,9 @@ class TimeStampParams(BaseModel):
         if from_timestamp > value:
             raise ValueError(
                 "Timestamp difference should be in order")
-        if timestamp_diff > timedelta(hours=24):
+        if timestamp_diff > timedelta(weeks=1):
             raise ValueError(
-                "Timestamp difference must be lower than 24 hours")
+                "Timestamp difference must be lower than 1 week")
 
         return value
 


### PR DESCRIPTION
After replacing Insights with the more performant Underpass as the default data source, we're now able to expand the time limit.