### PR TITLE
Fix python version in workflow and Ubuntu version

### DIFF
--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy:
     runs-on:
-      ubuntu-latest
+      ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6.9
+          python-version: 3.8
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Some GitHub actions failed because `Python 3.6.9` is not found ([this one](https://github.com/hotosm/galaxy-api/actions/runs/3531911379/jobs/5925623880) and [this one](https://github.com/hotosm/galaxy-api/actions/runs/3531572497/jobs/5926025763)) whereas the description of the task is `Set up Python 3.8`.

There is also an issue when installing `postgresql-12-postgis-3` because [GitHub actions now run on Ubuntu 22 instead of Ubuntu 20 as before](https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/).
I put again Unit Test workflow on Ubuntu 20.04 but it is maybe better to migrate to `postgresql-14-postgis-3`.